### PR TITLE
fix the tooltip description of btnNewLinePushButton in expression builder

### DIFF
--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -250,7 +250,7 @@
                  <item>
                   <widget class="QPushButton" name="btnNewLinePushButton">
                    <property name="toolTip">
-                    <string>Close Bracket </string>
+                    <string>New Line </string>
                    </property>
                    <property name="text">
                     <string>'\n'</string>


### PR DESCRIPTION
Replace "Close Bracket " by "New Line "