### PR TITLE
Use correct argument name

### DIFF
--- a/resources/function_help/json/make_circle
+++ b/resources/function_help/json/make_circle
@@ -7,7 +7,7 @@
   "arguments": [
     {"arg":"center", "description": "center point of the circle"},
     {"arg":"radius", "description": "radius of the circle"},
-    {"arg":"segment", "optional": true, "default": "36", "description": "optional argument for polygon segmentation. By default this value is 36"}
+    {"arg":"segments", "optional": true, "default": "36", "description": "optional argument for polygon segmentation. By default this value is 36"}
   ],
   "examples": [
     { "expression":"geom_to_wkt(make_circle(make_point(10,10), 5, 4))", "returns":"'Polygon ((10 15, 15 10, 10 5, 5 10, 10 15))'"},

--- a/resources/function_help/json/make_ellipse
+++ b/resources/function_help/json/make_ellipse
@@ -9,7 +9,7 @@
     {"arg":"semi_major_axis", "description": "semi-major axis of the ellipse"},
     {"arg":"semi_minor_axis", "description": "semi-minor axis of the ellipse"},
     {"arg":"azimuth", "description": "orientation of the ellipse"},
-    {"arg":"segment", "optional": true, "default": "36", "description": "optional argument for polygon segmentation. By default this value is 36"}
+    {"arg":"segments", "optional": true, "default": "36", "description": "optional argument for polygon segmentation. By default this value is 36"}
   ],
   "examples": [
     { "expression":"geom_to_wkt(make_ellipse(make_point(10,10), 5, 2, 90, 4))", "returns":"'Polygon ((15 10, 10 8, 5 10, 10 12, 15 10))'"},


### PR DESCRIPTION
## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
