### PR TITLE
Add tooltip to the last mesh symbology tab

### DIFF
--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -409,6 +409,9 @@
       <attribute name="title">
        <string/>
       </attribute>
+      <attribute name="toolTip">
+       <string>Stacked mesh averaging method</string>
+      </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <property name="leftMargin">
         <number>0</number>


### PR DESCRIPTION
Implements https://github.com/qgis/QGIS/pull/44214#issuecomment-882631768 
![meshtabs](https://user-images.githubusercontent.com/7983394/127149343-2cbf0a80-6e77-4c11-8f47-eddf766f7738.gif)
though I wonder if a smaller tab name would not be better (`Stacked method`, `Averaging method`? but I have an incomplete understanding of all this)
Also, based on what I seem to understand from [QEP 158](https://github.com/qgis/QGIS-Enhancement-Proposals/issues/158): should we not activate this tab only when there is a volume dataset group involved (as we do for contours and vectors tab)? I can open an issue report if so.
