### PR TITLE
Fix "add tab or group container" dialog resizing

### DIFF
--- a/src/ui/qgsaddtaborgroupbase.ui
+++ b/src/ui/qgsaddtaborgroupbase.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string notr="true">Dialog</string>
   </property>
-  <layout class="QFormLayout" name="formLayout">
+  <layout class="QGridLayout" name="gridLayout_0">
    <item row="0" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">


### PR DESCRIPTION
Use gridLayout instead of formLayout
Before 
![image](https://user-images.githubusercontent.com/7983394/142573399-86f0c7d1-8725-424d-8c8f-7bc9214c4475.png)
After
![image](https://user-images.githubusercontent.com/7983394/142573422-8c7766af-648c-490d-93dd-09149d249f87.png)
