### PR TITLE
Indicate actual repository storing the build artifacts in comment

### DIFF
--- a/.github/workflows/build_artifact_comment.yml
+++ b/.github/workflows/build_artifact_comment.yml
@@ -77,10 +77,10 @@ jobs:
             });
             const PREFIX = "## 🪟 Windows builds ready!";
             let body = PREFIX + "\n\n" +
-                "Windows builds of this PR are available for testing [here](https://github.com/qgis/QGIS/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.artifact_id}}).";
+                "Windows builds of this PR are available for testing [here](https://github.com/" + context.repo.owner + "/" + context.repo.repo + "/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.artifact_id}}).";
             if ( ${{steps.download_artifact.outputs.debug_symbols_artifact_id}} > 0 )
             {
-              body += " Debug symbols for this build are available [here](https://github.com/qgis/QGIS/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.debug_symbols_artifact_id}}).";
+              body += " Debug symbols for this build are available [here](https://github.com/" + context.repo.owner + "/" + context.repo.repo + "/suites/" +  context.payload.workflow_run.check_suite_id + "/artifacts/${{steps.download_artifact.outputs.debug_symbols_artifact_id}}).";
             }
             body += "\n\n*(Built from commit " + git_sha + ")*";
 


### PR DESCRIPTION
When people are using a repo other than qgis/QGIS to build their artifacts, let's ensure we provide the correct link and not point to upstream repo