### PR TITLE
Sort the list of raster format extensions displayed in Processing gen…

### DIFF
--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -1206,7 +1206,7 @@ QList< QgsRasterFileWriter::FilterFormatDetails > QgsRasterFileWriter::supported
 QStringList QgsRasterFileWriter::supportedFormatExtensions( const RasterFormatOptions options )
 {
   const auto formats = supportedFiltersAndFormats( options );
-  QStringList extensions;
+  QSet< QString > extensions;
 
   const thread_local QRegularExpression rx( QStringLiteral( "\\*\\.([a-zA-Z0-9]*)" ) );
 
@@ -1218,7 +1218,31 @@ QStringList QgsRasterFileWriter::supportedFormatExtensions( const RasterFormatOp
       continue;
 
     const QString matched = match.captured( 1 );
-    extensions << matched;
+    extensions.insert( matched );
   }
-  return extensions;
+
+  QStringList extensionList( extensions.constBegin(), extensions.constEnd() );
+
+  std::sort( extensionList.begin(), extensionList.end(), [options]( const QString & a, const QString & b ) -> bool
+  {
+    if ( options & SortRecommended )
+    {
+      if ( a == QLatin1String( "tif" ) )
+        return true;
+      else if ( b == QLatin1String( "tif" ) )
+        return false;
+      if ( a == QLatin1String( "tiff" ) )
+        return true;
+      else if ( b == QLatin1String( "tiff" ) )
+        return false;
+      if ( a == QLatin1String( "gpkg" ) )
+        return true;
+      else if ( b == QLatin1String( "gpkg" ) )
+        return false;
+    }
+
+    return a.toLower().localeAwareCompare( b.toLower() ) < 0;
+  } );
+
+  return extensionList;
 }


### PR DESCRIPTION
…eral options

## Description

[Replace this with some text explaining the rationale and details about this pull request]

<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - You have run the `scripts/prepare_commit.sh` script (https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit.
    If you didn't do this, you can also run `./scripts/astyle_all.sh` from your source folder.

  - You have read the QGIS Coding Standards (https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
-->
